### PR TITLE
Link generated types in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.0.3",
   "description": "Node stream mock module",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "repository": "https://github.com/BastienAr/stream-mock.git",
   "author": "Bastien Arata <bastyen.a@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This will allow the TypeScript compiler to use the typings packaged on npm (which are already in there). They were just not linked before.