### PR TITLE
Remove unused import in README example snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ export default class Rounder extends Transform {
 Now you need / want to test it.
 
 ```javascript
-import {ObjectReadableMock, ObjectWritableMock, DuplexMock } from 'stream-mock';
+import { ObjectReadableMock, ObjectWritableMock } from 'stream-mock';
 import chai from 'chai';
 
 import Rounder from 'the/seven/bloody/hells';


### PR DESCRIPTION
I hope this is self explanatory 🤠 I don't see how the `DuplexMock` import is used in that snippet.